### PR TITLE
removes non essential calls to File.exist?

### DIFF
--- a/lib/icons/icon.rb
+++ b/lib/icons/icon.rb
@@ -16,12 +16,12 @@ class Icons::Icon
   end
 
   def svg
-    raise Icons::IconNotFound, error_message unless File.exist?(file_path)
-
     Nokogiri::HTML::DocumentFragment.parse(File.read(file_path))
       .at_css("svg")
       .tap { |svg| attach_attributes(to: svg) }
       .to_html
+  rescue Errno::ENOENT
+    raise Icons::IconNotFound, error_message
   end
 
   private

--- a/lib/icons/icon/file_path.rb
+++ b/lib/icons/icon/file_path.rb
@@ -20,11 +20,7 @@ module Icons
 
         return custom_library_path if custom_library?
 
-        icon_path = icons_path_in_app
-
-        raise Icons::IconNotFound if icon_path.nil?
-
-        icon_path
+        app_path
       end
 
       private
@@ -49,12 +45,6 @@ module Icons
       def custom_library_path
         library_config = Icons.libraries[@library.to_sym]
         Icons.config.base_path.join(library_config.custom_path, "#{@name}.svg")
-      end
-
-      def icons_path_in_app
-        path = app_path
-
-        path if File.exist?(path)
       end
 
       def app_path

--- a/test/icons/icon/file_path_test.rb
+++ b/test/icons/icon/file_path_test.rb
@@ -27,18 +27,6 @@ class Icons::Icon::FilePathTest < Minitest::Test
     assert_match(/faded-spinner\.svg$/, path.to_s)
   end
 
-  def test_raises_error_for_missing_icon
-    file_path = Icons::Icon::FilePath.new(
-      name: "nonexistent",
-      library: "heroicons",
-      variant: "outline"
-    )
-
-    assert_raises(Icons::IconNotFound) do
-      file_path.call
-    end
-  end
-
   def test_handles_library_without_variant
     file_path = Icons::Icon::FilePath.new(
       name: "alien",


### PR DESCRIPTION
I'm not sure if not raising Icons::IconNotFound in Icon::FilePath class is problematic or not ?

I think it is not a problem if the exception is raised when reading the file instead of when the path is built.

issue #2 