### PR TITLE
Support for svg transformations

### DIFF
--- a/lib/icons/configuration/boxicons.rb
+++ b/lib/icons/configuration/boxicons.rb
@@ -50,7 +50,11 @@ module Icons
         {
           filenames: {
             delete_prefix: ["bxl-", "bx-", "bxs-"]
-          }
+          },
+
+          svg: [
+            {element: "path", action: :set_attribute, attribute: "fill", value: "currentColor"}
+          ]
         }
       end
 

--- a/lib/icons/sync/process_variants.rb
+++ b/lib/icons/sync/process_variants.rb
@@ -47,10 +47,13 @@ module Icons
 
       def apply_transformations_to(destination)
         Dir.each_child(destination) do |filename|
-          File.rename(
-            File.join(destination, filename),
-            File.join(destination, Sync::Transformations.transform(filename, transformations.fetch(:filenames, {})))
-          )
+          original_file_path = File.join(destination, filename)
+          transformed_filename = Sync::Transformations.transform(filename, transformations)
+          transformed_file_path = File.join(destination, transformed_filename)
+
+          File.rename(original_file_path, transformed_file_path)
+
+          transform_svg(transformed_file_path)
         end
       end
 
@@ -74,6 +77,14 @@ module Icons
         else
           {}
         end
+      end
+
+      def transform_svg(file_path)
+        return if File.extname(file_path) != ".svg"
+
+        svg_transformations = transformations.fetch(:svg, [])
+
+        Sync::Transformations.transform_svg(file_path, svg_transformations)
       end
     end
   end

--- a/lib/icons/sync/transformations.rb
+++ b/lib/icons/sync/transformations.rb
@@ -1,27 +1,54 @@
 # frozen_string_literal: true
 
+require "nokogiri"
+
 module Icons
   class Sync
     class Transformations
       def self.transform(filename, rules = {})
         basename = File.basename(filename, File.extname(filename))
 
-        transformed = rules.reduce(basename) do |fn, (type, value)|
-          TRANSFORMERS.fetch(type).call(fn, value)
+        transformed = rules.fetch(:filenames, {}).reduce(basename) do |fn, (type, value)|
+          FILENAME_TRANSFORMERS.fetch(type).call(fn, value)
         end
 
         [transformed, File.extname(filename)].join
       end
 
+      def self.transform_svg(file_path, rules = [])
+        return unless rules.any?
+
+        svg_document = Nokogiri::HTML::DocumentFragment.parse(File.read(file_path))
+
+        rules.each do |rule|
+          SVG_TRANSFORMERS.fetch(rule[:action]).call(
+            svg_document,
+            rule[:element],
+            rule[:attribute],
+            rule[:value]
+          )
+        end
+
+        File.write(file_path, svg_document.to_html)
+      end
+
       private
 
-      TRANSFORMERS = {
+      FILENAME_TRANSFORMERS = {
         delete_prefix: ->(filename, prefixes) {
           Array(prefixes).reduce(filename) { |fn, prefix| fn.delete_prefix(prefix) }
         },
 
         delete_suffix: ->(filename, suffixes) {
           Array(suffixes).reduce(filename) { |fn, suffix| fn.delete_suffix(suffix) }
+        }
+      }
+
+      SVG_TRANSFORMERS = {
+        set_attribute: ->(document, element_selector, attribute_name, attribute_value) {
+          document.css(element_selector).each do |element|
+            element[attribute_name] = attribute_value
+          end
         }
       }
     end

--- a/test/icons/sync/process_variants_test.rb
+++ b/test/icons/sync/process_variants_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "fileutils"
+require "icons/sync/process_variants"
+
+class Icons::Sync::ProcessVariantsTest < Minitest::Test
+  def test_process_applies_svg_content_transformations
+    Dir.mktmpdir do |temp_directory|
+      source_directory = File.join(temp_directory, "svg", "basic")
+
+      FileUtils.mkdir_p(source_directory)
+      File.write(File.join(source_directory, "test.svg"), '<svg xmlns="http://www.w3.org/2000/svg"><path d="M2 3h2v18H2z"/></svg>')
+
+      library = { variants: { regular: "svg/basic" } }
+
+      processor = Icons::Sync::ProcessVariants.new(temp_directory, "boxicons", library)
+      processor.process
+
+      result_file = File.join(temp_directory, "regular", "test.svg")
+      assert File.exist?(result_file), "Expected SVG file to exist at #{result_file}"
+
+      result = File.read(result_file)
+      assert_includes result, 'fill="currentColor"'
+    end
+  end
+end

--- a/test/icons/sync/transformations_test.rb
+++ b/test/icons/sync/transformations_test.rb
@@ -7,7 +7,7 @@ class Icons::Sync::TransformationsTest < Minitest::Test
   def test_delete_prefix
     result = Icons::Sync::Transformations.transform(
       "icon-test.svg",
-      {delete_prefix: "icon-"}
+      { filenames: { delete_prefix: "icon-" } }
     )
 
     assert_equal "test.svg", result
@@ -16,7 +16,7 @@ class Icons::Sync::TransformationsTest < Minitest::Test
   def test_delete_suffix
     result = Icons::Sync::Transformations.transform(
       "test-icon.svg",
-      {delete_suffix: "-icon"}
+      { filenames: { delete_suffix: "-icon" } }
     )
 
     assert_equal "test.svg", result
@@ -25,7 +25,7 @@ class Icons::Sync::TransformationsTest < Minitest::Test
   def test_delete_multiple_prefixes
     result = Icons::Sync::Transformations.transform(
       "icon-prefix-test.svg",
-      {delete_prefix: ["icon-", "prefix-"]}
+      { filenames: { delete_prefix: ["icon-", "prefix-"] } }
     )
 
     assert_equal "test.svg", result
@@ -35,5 +35,40 @@ class Icons::Sync::TransformationsTest < Minitest::Test
     result = Icons::Sync::Transformations.transform("test.svg", {})
 
     assert_equal "test.svg", result
+  end
+
+  def test_svg_set_attribute
+    svg_content = '<svg xmlns="http://www.w3.org/2000/svg"><path d="M2 3h2v18H2z"/></svg>'
+
+    Tempfile.create(["test", ".svg"]) do |file|
+      file.write(svg_content)
+      file.close
+
+      Icons::Sync::Transformations.transform_svg(
+        file.path,
+        [{ element: "path", action: :set_attribute, attribute: "fill", value: "currentColor" }]
+      )
+
+      result = File.read(file.path)
+      assert_includes result, 'fill="currentColor"'
+    end
+  end
+
+  def test_svg_set_attribute_preserves_existing
+    svg_content = '<svg xmlns="http://www.w3.org/2000/svg"><path fill="blue" d="M2 3h2v18H2z"/></svg>'
+
+    Tempfile.create(["test", ".svg"]) do |file|
+      file.write(svg_content)
+      file.close
+
+      Icons::Sync::Transformations.transform_svg(
+        file.path,
+        [{ element: "path", action: :set_attribute, attribute: "fill", value: "currentColor" }]
+      )
+
+      result = File.read(file.path)
+      assert_includes result, 'fill="currentColor"'
+      refute_includes result, 'fill="blue"'
+    end
   end
 end


### PR DESCRIPTION
Allows to transform SVGs, e.g. by adding `fill=currentColor`

Resolves https://github.com/Rails-Designer/rails_icons/issues/109