### PR TITLE
Optimize icon library sync with sparse clone

### DIFF
--- a/lib/icons/sync.rb
+++ b/lib/icons/sync.rb
@@ -6,7 +6,7 @@ require "icons/sync/process_variants"
 module Icons
   class Sync
     def initialize(name)
-      raise "[Icons] Not a valid library" if Icons.libraries.keys.exclude?(name.to_sym)
+      raise "[Icons] Not a valid library" unless Icons.libraries.key?(name.to_sym)
 
       @name = name
       @library = Icons.libraries.fetch(name.to_sym).source
@@ -36,9 +36,23 @@ module Icons
     end
 
     def clone_repository
-      raise "[Icons] Failed to clone repository" unless system("git clone '#{@library[:url]}' '#{@temp_directory}'")
+      unless clone_repository_sparse
+        puts "[Icons] Sparse clone failed, falling back to full clone"
+        FileUtils.rm_rf(@temp_directory)
+
+        raise "[Icons] Failed to clone repository" unless system("git clone '#{@library[:url]}' '#{@temp_directory}'")
+      end
 
       puts "[Icons] '#{@name}' repository cloned"
+    end
+
+    def clone_repository_sparse
+      system("git clone --depth 1 --filter=blob:none --sparse '#{@library[:url]}' '#{@temp_directory}'") &&
+        system("git -C '#{@temp_directory}' sparse-checkout set #{sparse_checkout_paths}")
+    end
+
+    def sparse_checkout_paths
+      @library[:variants].values.map { |path| "'#{path}'" }.join(" ")
     end
 
     def process_variants

--- a/test/icons/sync_test.rb
+++ b/test/icons/sync_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Icons::SyncTest < Minitest::Test
+  def test_clone_repository_uses_shallow_partial_sparse_clone
+    sync = Icons::Sync.new("tabler")
+    commands = stub_system_on(sync) { |cmd| true }
+
+    capture_io { sync.send(:clone_repository) }
+
+    td = temp_dir
+    assert_equal [
+      "git clone --depth 1 --filter=blob:none --sparse 'https://github.com/tabler/tabler-icons.git' '#{td}'",
+      "git -C '#{td}' sparse-checkout set 'icons/filled' 'icons/outline'"
+    ], commands
+  end
+
+  def test_clone_repository_falls_back_to_full_clone_when_optimized_clone_fails
+    sync = Icons::Sync.new("tabler")
+    commands = stub_system_on(sync) { |cmd| !cmd.include?("--filter=blob:none") }
+
+    capture_io { sync.send(:clone_repository) }
+
+    td = temp_dir
+    assert commands.first.include?("--filter=blob:none"),
+      "Expected first command to be the sparse clone attempt"
+    assert_equal "git clone 'https://github.com/tabler/tabler-icons.git' '#{td}'", commands.last
+  end
+
+  def test_clone_repository_raises_when_full_clone_also_fails
+    sync = Icons::Sync.new("tabler")
+    stub_system_on(sync) { |cmd| false }
+
+    assert_raises(RuntimeError) { capture_io { sync.send(:clone_repository) } }
+  end
+
+  private
+
+  def temp_dir
+    Icons.configuration.base_path.join("tmp/icons/tabler").to_s
+  end
+
+  def stub_system_on(sync, &block)
+    commands = []
+    sync.define_singleton_method(:system) { |cmd| commands << cmd; block.call(cmd) }
+    commands
+  end
+end


### PR DESCRIPTION
Thanks for this useful project! I've come up with an improvement to an issue specifically noticeable on slower networks.

Icon source repos (e.g. `tabler-icons`) are large almost entirely due to their git history and unused directories, all of which is discarded after the variant SVG directories are moved out.

Instead of checking out the full repository, prefer a sparse clone that fetches only the latest commit and only the blobs for the variant directories declared in each library's source config:
```
  git clone --depth 1 --filter=blob:none --sparse <url> <dir>
  git -C <dir> sparse-checkout set <variant paths...>
```

For tabler-icons this decreases the checkout size from 1.2GB to 29MB with identical output. If the optimized clone fails for any reason (old `git` without sparse-checkout, a host without partial-clone support, etc.) it cleans up and falls back to the original full clone, so behavior is never worse than before.

Add tests and avoid using ActiveSupport in the `Sync` initializer as we don't have access to it outside of Rails.